### PR TITLE
fix: change snapshot index for mongodb

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     {
       "name": "René Viering",
       "email": "rene.viering@gmail.com"
+    },
+    {
+      "name": "Adam Koleszar",
+      "email": "madfist@gmail.com"
     }
   ],
   "dependencies": {

--- a/src/mongodb/Eventstore.js
+++ b/src/mongodb/Eventstore.js
@@ -55,7 +55,7 @@ class Eventstore extends EventEmitter {
     await this.collections.events.ensureIndex({ 'aggregate.id': 1 }, { name: `${this.namespace}_aggregateId` });
     await this.collections.events.ensureIndex({ 'aggregate.id': 1, 'metadata.revision': 1 }, { unique: true, name: `${this.namespace}_aggregateId_revision` });
     await this.collections.events.ensureIndex({ 'metadata.position': 1 }, { unique: true, name: `${this.namespace}_position` });
-    await this.collections.snapshots.ensureIndex({ 'aggregate.id': 1 }, { unique: true });
+    await this.collections.snapshots.ensureIndex({ aggregateId: 1 }, { unique: true });
 
     try {
       await this.collections.counters.insertOne({ _id: 'events', seq: 0 });

--- a/test/units/getTestsFor.js
+++ b/test/units/getTestsFor.js
@@ -863,6 +863,30 @@ const getTestsFor = function (Eventstore, { url, type, startContainer, stopConta
       });
     });
 
+    test('saves multiple snapshots', async () => {
+      const state = {
+        initiator: 'Jane Doe',
+        destination: 'Riva',
+        participants: [ 'Jane Doe' ]
+      };
+
+      const aggregateIds = [uuid(), uuid(), uuid()];
+      await eventstore.initialize({ url, namespace });
+      
+      for (const aggregateId of aggregateIds) {
+        await eventstore.saveSnapshot({ aggregateId, revision: 10, state });
+      }
+
+      for (const aggregateId of aggregateIds) {
+        let snapshot = await eventstore.getSnapshot(aggregateId);
+
+        assert.that(snapshot).is.equalTo({
+          revision: 10,
+          state
+        });
+      }
+    });
+
     test('correctly handles null, undefined and empty arrays.', async () => {
       const aggregateId = uuid();
       const state = {


### PR DESCRIPTION
Snapshots have `aggregateId` not `aggregate.id` so creating more than
one snapshot does not work with mongodb

Signed-off-by: Adam Koleszar <madfist@gmail.com>