### PR TITLE
feat(postgres): Add ssl option for postgres driver

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1361,6 +1361,11 @@
         "safe-buffer": "^5.1.1"
       }
     },
+    "boolean": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-1.0.0.tgz",
+      "integrity": "sha512-IB1lgIywn37N9Aff8CciCblVpMUflgL42vyxPUH0IvaDdIi/QwBHKv1lq/HOkATHCfa7c4MbMYJ7Bo7hGuoI+w=="
+    },
     "boxen": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -2788,7 +2793,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2809,12 +2815,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2829,17 +2837,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2956,7 +2967,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2968,6 +2980,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2982,6 +2995,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2989,12 +3003,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3013,6 +3029,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3093,7 +3110,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3105,6 +3123,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3190,7 +3209,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3226,6 +3246,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3245,6 +3266,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3288,12 +3310,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "dependencies": {
     "async-retry": "1.2.3",
     "babel-runtime": "6.26.0",
+    "boolean": "^1.0.0",
     "commands-events": "1.0.4",
     "dsn-parser": "1.0.1",
     "limit-alphanumeric": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,14 @@
     {
       "name": "Adam Koleszar",
       "email": "madfist@gmail.com"
+    },
+    {
+      "name": "Manfred Mjka",
+      "email": "manfred.mjka@sclable.com"
+    },
+    {
+      "name": "Lorenz Leutgeb",
+      "email": "lorenz.leutgeb@sclable.com"
     }
   ],
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "async-retry": "1.2.3",
     "babel-runtime": "6.26.0",
-    "boolean": "^1.0.0",
+    "boolean": "1.0.0",
     "commands-events": "1.0.4",
     "dsn-parser": "1.0.1",
     "limit-alphanumeric": "1.0.0",

--- a/src/postgres/Eventstore.js
+++ b/src/postgres/Eventstore.js
@@ -3,15 +3,15 @@
 const { EventEmitter } = require('events'),
       { PassThrough } = require('stream');
 
-const cloneDeep = require('lodash/cloneDeep'),
+const boolean = require('boolean'),
+      cloneDeep = require('lodash/cloneDeep'),
       DsnParser = require('dsn-parser'),
       { Event } = require('commands-events'),
       flatten = require('lodash/flatten'),
       limitAlphanumeric = require('limit-alphanumeric'),
       pg = require('pg'),
       QueryStream = require('pg-query-stream'),
-      retry = require('async-retry'),
-      boolean = require('boolean');
+      retry = require('async-retry');
 
 const omitByDeep = require('../omitByDeep');
 
@@ -37,7 +37,7 @@ class Eventstore extends EventEmitter {
     this.namespace = `store_${limitAlphanumeric(namespace)}`;
 
     const { host, port, user, password, database, params } = new DsnParser(url).getParts();
-    const ssl = boolean(params.ssl)
+    const ssl = boolean(params.ssl);
 
     this.pool = new pg.Pool({ host, port, user, password, database, ssl });
     this.pool.on('error', () => {
@@ -46,7 +46,7 @@ class Eventstore extends EventEmitter {
 
     const connection = await this.getDatabase();
 
-    const disconnectWatcher = new pg.Client({ host, port, user, password, database, ssl });
+    this.disconnectWatcher = new pg.Client({ host, port, user, password, database, ssl });
 
     this.disconnectWatcher.on('error', () => {
       this.emit('disconnect');

--- a/src/postgres/Eventstore.js
+++ b/src/postgres/Eventstore.js
@@ -35,16 +35,16 @@ class Eventstore extends EventEmitter {
 
     this.namespace = `store_${limitAlphanumeric(namespace)}`;
 
-    const { host, port, user, password, database } = new DsnParser(url).getParts();
+    const { host, port, user, password, database, params } = new DsnParser(url).getParts();
 
-    this.pool = new pg.Pool({ host, port, user, password, database });
+    this.pool = new pg.Pool({ host, port, user, password, database, ssl: params.ssl === 'true' });
     this.pool.on('error', () => {
       this.emit('disconnect');
     });
 
     const connection = await this.getDatabase();
 
-    const disconnectWatcher = new pg.Client({ host, port, user, password, database });
+    const disconnectWatcher = new pg.Client({ host, port, user, password, database, ssl: params.ssl === 'true' });
 
     disconnectWatcher.on('error', () => {
       this.emit('disconnect');


### PR DESCRIPTION
We're consuming `wolkenkit-eventstore` (and in particular its Postgres driver). However we need secure connections, so my colleague @manfredmjka came up with this patch.
Any chance to get it upstreamed? Maybe you could help us out be generalizing this to the other database drivers?