### PR TITLE
Update dependency "lodash"

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "commands-events": "thenativeweb/commands-events#ca11473cfb1de65d65d0342540e33e7acfa4dc78",
     "dsn-parser": "1.0.1",
     "limit-alphanumeric": "1.0.0",
-    "lodash": "4.17.11",
+    "lodash": "4.17.15",
     "mongodb": "3.2.3",
     "mysql2": "1.5.3",
     "pg": "7.9.0",


### PR DESCRIPTION
lodash 4.17.11 was vulnernable to Prototype Pollution,see https://npmjs.com/advisories/1065